### PR TITLE
space테이블 단일테이블 전략 ->테이블 퍼 클래스로 수정

### DIFF
--- a/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/MemberSpace.java
+++ b/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/MemberSpace.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 import withSpace_test2.withSpace_test2.domain.Member;
 
 @Entity
-@DiscriminatorValue("member")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/Space.java
+++ b/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/Space.java
@@ -9,8 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "space_type") //member스페이스, team 스페이스
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 @Getter
 @Setter
 public abstract class Space {
@@ -19,9 +18,6 @@ public abstract class Space {
     @GeneratedValue
     @Column(name = "space_id")
     private Long id;
-
-    @Column(name = "space_type", insertable = false, updatable = false)
-    private String type;
 
     @OneToMany(mappedBy = "space", cascade = CascadeType.ALL)
     private List<Page> pageList = new ArrayList<>();

--- a/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/TeamSpace.java
+++ b/withSpace_test2/src/main/java/withSpace_test2/withSpace_test2/domain/space/TeamSpace.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 import withSpace_test2.withSpace_test2.domain.Team;
 
 @Entity
-@DiscriminatorValue("team")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
* space 테이블 단일테이블 전략 ->테이블 퍼 클래스로 수정
* 단일테이블 전략 테이블
![image](https://user-images.githubusercontent.com/90665186/221345289-ca86b7a8-2438-468a-a060-be1f79176134.png)
* 테이블 퍼 클래스 테이블
![image](https://user-images.githubusercontent.com/90665186/221345312-4f37f545-cc35-4726-b02d-5e5944683cbb.png)
단일 테이블 전략 때 space테이블에 team_id속성이 불필요하게 쓰이는걸 없앰